### PR TITLE
chore: update ecosystem list to compat v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# osv - A rust client library for https://api.osv.dev
+# osv - A rust client library for the OSV schema
 
 <div align="center">
   <a href="https://crates.io/crates/osv">
@@ -17,6 +17,8 @@
 https://osv.dev is a vulnerability database and triage infrastructure
 for open source projects. This library provides bindings to osv 
 API to allow usage from the Rust language.
+
+Currently compatible with v1.3.0 of the ossf/osv-schema.
 
 ### References
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,9 @@ pub enum Ecosystem {
     Debian,
     Hex,
     Android,
+    #[serde(rename = "GitHub Actions")]
+    GitHubActions,
+    Pub,
 }
 
 /// Type of the affected range supplied. This can be an ecosystem
@@ -655,5 +658,5 @@ mod tests {
         assert!(!str_json.contains("database_specific"));
     }
 
-    
+
 }


### PR DESCRIPTION
Changes to the ossf/osv spec introduced two new Ecosystems. Github Actions and Pub format for Dart.

Relates to: https://github.com/ossf/osv-schema/releases/tag/v1.3.0