### PR TITLE
Add smoke tests

### DIFF
--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::fs;
+use std::process;
+
+#[async_std::main]
+async fn main() -> Result<(), osv::ApiError> {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.len() <= 0 {
+        println!("filename expected");
+        process::exit(1);
+    }
+    for arg in &args {
+        let path: &str = arg.as_str();
+        let file = fs::File::open(path).unwrap();
+        let _vuln: osv::Vulnerability =
+            serde_json::from_reader(file).expect(&format!("fail: {}", path));
+        println!("pass: {}", path);
+    }
+    Ok(())
+}

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# This script downloads all the json dumps from GCP and make sure we
+# can deserialize them as strongly typed values.
+# 
+# Requirements:
+#
+# - Google Cloud CLI installed: https://cloud.google.com/sdk/docs/install
+# - fd: https://github.com/sharkdp/fd
+#
+#############################################################################
+
+
+ensure_exists() {
+    if ! command -v "$1" &>/dev/null
+    then
+        echo "$1 requirement not met"
+        exit 1;
+    fi
+}
+
+download() {
+    buckets=$(gsutil ls gs://osv-vulnerabilities | grep -v ecosystems.txt)
+    for subdir in $buckets
+    do
+        target=$(
+            echo "$subdir" | \
+            sed -e 's/gs.*osv-vulnerabilities//' \
+                -e 's/\///g' \
+                -e 's/:/_/'
+        )
+        mkdir -p "$(pwd)/testdata/$target"
+        gsutil cp "${subdir}all.zip" "$(pwd)/testdata/$target"
+    done
+}
+
+extract() {
+    for zipfile in $(fd all.zip)
+    do 
+        target=$(dirname "$zipfile")
+        unzip -d "$target" "$zipfile"
+    done
+}
+
+build(){
+    cargo run --example parse 2>/dev/null
+}
+
+find_bugs(){
+    fd -e json \
+        --exclude testdata/GSD \
+        --exclude testdata/DWF \
+        --exclude testdata/JavaScript \
+        --full-path ./testdata \
+        -x ./target/debug/examples/parse | grep -v pass
+}
+
+main(){
+    ensure_exists gsutil
+    ensure_exists fd
+    mkdir -p testdata
+    download
+    extract
+    build
+    find_bugs
+}
+
+main

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,26 @@ pub enum Ecosystem {
     NuGet,
     Linux,
     Debian,
+    #[serde(rename = "Debian:3.0")]
+    Debian3_0,
+    #[serde(rename = "Debian:3.1")]
+    Debian3_1,
+    #[serde(rename = "Debian:4.0")]
+    Debian4_0,
+    #[serde(rename = "Debian:5.0")]
+    Debian5_0,
+    #[serde(rename = "Debian:6.0")]
+    Debian6_0,
+    #[serde(rename = "Debian:7")]
+    Debian7,
+    #[serde(rename = "Debian:8")]
+    Debian8,
+    #[serde(rename = "Debian:9")]
+    Debian9,
+    #[serde(rename = "Debian:10")]
+    Debian10,
+    #[serde(rename = "Debian:11")]
+    Debian11,
     Hex,
     Android,
     #[serde(rename = "GitHub Actions")]
@@ -167,7 +187,8 @@ pub struct Affected {
 
     /// The range of versions or git commits that this vulnerability
     /// was first introduced and/or version that it was fixed in.
-    pub ranges: Vec<Range>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranges: Option<Vec<Range>>,
 
     /// Each string is a single affected version in whatever version syntax is
     /// used by the given package ecosystem.
@@ -629,20 +650,20 @@ mod tests {
     #[async_std::test]
     async fn test_no_serialize_null_fields() {
         let vuln = Vulnerability {
-          schema_version: "1.3.0".to_string(),
-          id: "OSV-2020-484".to_string(),
-          published: chrono::Utc::now(),
-          modified: chrono::Utc::now(),
-          withdrawn: None,
-          aliases: None,
-          related: None,
-          summary: None,
-          details: None,
-          affected: vec![],
-          references: None,
-          severity: None,
-          credits: None,
-          database_specific: None
+            schema_version: "1.3.0".to_string(),
+            id: "OSV-2020-484".to_string(),
+            published: chrono::Utc::now(),
+            modified: chrono::Utc::now(),
+            withdrawn: None,
+            aliases: None,
+            related: None,
+            summary: None,
+            details: None,
+            affected: vec![],
+            references: None,
+            severity: None,
+            credits: None,
+            database_specific: None,
         };
 
         let as_json = serde_json::json!(vuln);
@@ -657,6 +678,4 @@ mod tests {
         assert!(!str_json.contains("credits"));
         assert!(!str_json.contains("database_specific"));
     }
-
-
 }


### PR DESCRIPTION
This change introduces a way to check we can consume the bulk of the data in the `gs://osv-vulnerability` bucket. The result of this identified a couple of bugs around my interpretation of the spec. Specifically the format of the `Debian:xxx` ecosystem and the ability for `ranges` field to be optional or interchangeable with the `version` field. To run the smoketests you will need the google cloud cli tools installed to pull the data down locally. 

Fixes: #4 

