### PR TITLE
fix: Generate docs with all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["vulnerabilities", "security", "osv"]
 
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }


### PR DESCRIPTION
This is mostly just for convenience i.e. it's nicer to have all the documentation for a crate on docs.rs rather than having to download the crate and run `cargo doc`.