### PR TITLE
build: remove unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 edition = "2021"
 authors = ["Grant Murphy <gcmurphy@pm.me>"]
 repository = "https://github.com/gcmurphy/osv"
-documentation = "https://docs.rs/osv" 
+documentation = "https://docs.rs/osv"
 description = "Rust library for parsing the OSV schema and client API"
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,6 @@ reqwest = { version = "0.12", features = ["json"], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 thiserror = { version = "2.0", optional = true }
 url = { version = "2.3.1", optional = true }
-cargo-semver-checks = "0.39.0"
 
 [dev-dependencies]
 comfy-table = "7.1.1"


### PR DESCRIPTION
It doesn't seem to be needed. Also, it pulls in `gix`, which pulls in all other kind of dependencies (not needed). And causes build issues when another crate pulls in `maybe_async`.