### PR TITLE
Ecosystem updates and dataset retrieval capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,26 @@ all-features = true
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+lazy-regex = "3.4.1"
 reqwest = { version = "0.12", features = ["json"], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 thiserror = { version = "2.0", optional = true }
 url = { version = "2.3.1", optional = true }
-lazy-regex = "3.4.1"
+object_store = { version = "0.12.0", optional = true, features = ["gcp"] }
+futures = { version = "0.3.31", optional = true }
+
 
 [dev-dependencies]
 comfy-table = "7.1.1"
 cargo-release = "0.25.10"
 textwrap = { version = "0.16.1", features = ["default", "terminal_size"] }
 tokio-test = "0.4.3"
-cargo-sbom = "0.9.1"
 
 [features]
 default = ["schema"]
 schema = []
 client = ["dep:tokio", "dep:reqwest", "dep:url", "dep:thiserror", "schema"]
+data = ["dep:object_store", "dep:thiserror", "dep:futures", "dep:tokio"]
 
 [[example]]
 name = "commit"
@@ -54,3 +57,8 @@ required-features = ["client"]
 name = "vulnerability"
 path = "examples/vulnerability.rs"
 required-features = ["client"]
+
+[[example]]
+name = "fetch"
+path = "examples/fetch.rs"
+required-features = ["data"]

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -1,0 +1,20 @@
+use osv::data;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> Result<(), data::DataError> {
+    let service_account = PathBuf::from(r"./credentials.json");
+    let output_directory = PathBuf::from(r"./data");
+    //let prefix = Path::from(r"Ubuntu");
+
+    println!("Starting download of vulnerability data...");
+    let start = Instant::now();
+
+    data::download(&service_account, &output_directory, None).await?;
+
+    let duration = start.elapsed();
+    println!("Download completed in {:.2?}", duration);
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -185,8 +185,10 @@ pub async fn query(q: &Request) -> Result<Option<Vec<Vulnerability>>, ApiError> 
 ///     if let Some(vulns) = query_package(pkg, ver, PyPI).await.unwrap() {
 ///         for vuln in &vulns {
 ///             println!("{:#?} - {:#?}", vuln.id, vuln.details);
-///             for affected in &vuln.affected {
-///                 println!("    {:#?}", affected.ranges);
+///             if let Some(affected_range) = &vuln.affected {
+///                 for affected in affected_range {
+///                     println!("    {:#?}", affected.ranges);
+///                 }
 ///             }
 ///         }
 ///     } else {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,72 @@
+use futures::TryStreamExt;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::ObjectStore;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum DataError {
+    #[error("failed to access requested resource")]
+    ObjectStoreError(#[from] object_store::Error),
+
+    #[error("invalid file path")]
+    ServiceAccountError(String),
+
+    #[error("cache access error")]
+    CacheFileError(#[from] std::io::Error),
+
+    #[error("unexpected error has occurred")]
+    Unexpected,
+}
+
+pub async fn download(
+    service_account: &Path,
+    output_directory: &Path,
+    prefix: Option<&object_store::path::Path>,
+) -> Result<(), DataError> {
+    let sa_path = service_account
+        .to_str()
+        .ok_or_else(|| DataError::ServiceAccountError("Invalid UTF-8 path".to_string()))?;
+
+    let osv_data = GoogleCloudStorageBuilder::new()
+        .with_service_account_path(sa_path)
+        .with_url("gs://osv-vulnerabilities")
+        .build()?;
+
+    let stream = osv_data.list(prefix);
+    stream
+        .try_filter(|meta| {
+            let json_file = meta.location.extension() == Some("json");
+            async move { json_file }
+        })
+        .map_err(DataError::ObjectStoreError)
+        .try_for_each_concurrent(16, |meta| {
+            let objects = osv_data.clone();
+            async move {
+                let remote_path = meta.location.as_ref();
+                let local_path = output_directory.to_path_buf().join(remote_path);
+                let cached = if local_path.exists() {
+                    let metadata = std::fs::metadata(&local_path)?;
+                    let modified = metadata.modified()?;
+                    let remote_modified = meta.last_modified;
+                    let local_modified = chrono::DateTime::<chrono::Utc>::from(modified);
+                    remote_modified <= local_modified
+                } else {
+                    false
+                };
+                if !cached {
+                    if let Some(parent) = local_path.parent() {
+                        std::fs::create_dir_all(parent).map_err(|_| DataError::Unexpected)?;
+                    }
+                    let object_path = meta.location.clone();
+                    let data = objects.get(&object_path).await?.bytes().await?.to_vec();
+                    std::fs::write(&local_path, data).map_err(|_| DataError::Unexpected)?;
+                }
+                Ok(())
+            }
+        })
+        .await?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,6 @@ pub mod schema;
 
 #[cfg(feature = "client")]
 pub mod client;
+
+#[cfg(feature = "data")]
+pub mod data;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -75,6 +75,7 @@ pub enum Ecosystem {
         lts: bool,
     },
     UVI,
+    Wolfi,
 }
 
 impl Serialize for Ecosystem {
@@ -121,9 +122,9 @@ impl Serialize for Ecosystem {
             }
             Ecosystem::Npm => serializer.serialize_str("npm"),
             Ecosystem::NuGet => serializer.serialize_str("NuGet"),
-            Ecosystem::OpenSUSE(None) => serializer.serialize_str("OpenSUSE"),
+            Ecosystem::OpenSUSE(None) => serializer.serialize_str("openSUSE"),
             Ecosystem::OpenSUSE(Some(release)) => {
-                serializer.serialize_str(&format!("OpenSUSE:{}", release))
+                serializer.serialize_str(&format!("openSUSE:{}", release))
             }
             Ecosystem::OssFuzz => serializer.serialize_str("OSS-Fuzz"),
             Ecosystem::Packagist => serializer.serialize_str("Packagist"),
@@ -173,6 +174,7 @@ impl Serialize for Ecosystem {
                 serializer.serialize_str(&serialized)
             }
             Ecosystem::UVI => serializer.serialize_str("UVI"),
+            Ecosystem::Wolfi => serializer.serialize_str("Wolfi"),
         }
     }
 }
@@ -238,9 +240,9 @@ impl<'de> Deserialize<'de> for Ecosystem {
                     )),
                     "npm" => Ok(Ecosystem::Npm),
                     "NuGet" => Ok(Ecosystem::NuGet),
-                    "OpenSUSE" => Ok(Ecosystem::OpenSUSE(None)),
-                    _ if value.starts_with("OpenSUSE:") => Ok(Ecosystem::OpenSUSE(
-                        value.strip_prefix("OpenSUSE:").map(|v| v.to_string()),
+                    "openSUSE" => Ok(Ecosystem::OpenSUSE(None)),
+                    _ if value.starts_with("openSUSE:") => Ok(Ecosystem::OpenSUSE(
+                        value.strip_prefix("openSUSE:").map(|v| v.to_string()),
                     )),
                     "OSS-Fuzz" => Ok(Ecosystem::OssFuzz),
                     "Packagist" => Ok(Ecosystem::Packagist),
@@ -279,6 +281,7 @@ impl<'de> Deserialize<'de> for Ecosystem {
                         ).ok_or(de::Error::unknown_variant(value, &["Ecosystem"]))
                     }
                     "UVI" => Ok(Ecosystem::UVI),
+                    "Wolfi" => Ok(Ecosystem::Wolfi),
                     _ => Err(de::Error::unknown_variant(value, &["Ecosystem"])),
                 }
             }
@@ -600,7 +603,7 @@ pub struct Vulnerability {
     pub details: Option<String>,
 
     /// Indicates the specific package ranges that are affected by this vulnerability.
-    pub affected: Vec<Affected>,
+    pub affected: Option<Vec<Affected>>,
 
     /// An optional list of external reference's that provide more context about this
     /// vulnerability.
@@ -640,7 +643,7 @@ mod tests {
             related: None,
             summary: None,
             details: None,
-            affected: vec![],
+            affected: None,
             references: None,
             severity: None,
             credits: None,


### PR DESCRIPTION
- Fix #60 so affected field is optional
- Fix #59 to handle openSUSE and Wolfi ecosystems
- Add ability to download a set of the osv dataset from a gcs bucket.